### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ These can be used to test pages from a custom repository
 or any zip collection that follows the official TLDR directory format
 and file specification.
 
-Pages: `https://raw.githubusercontent.com/tldr-pages/tldr/master/pages/`
+Pages: `https://raw.githubusercontent.com/tldr-pages/tldr/main/pages/`
 
 Zip: `https://tldr-pages.github.io/assets/tldr.zip`
 

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	zip = "https://tldr-pages.github.io/assets/tldr.zip"
-	raw = "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages/"
+	raw = "https://raw.githubusercontent.com/tldr-pages/tldr/main/pages/"
 )
 
 // Pages provides the retrieval of the TLDR assets and repository pages.


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).