### PR TITLE
fix: update tldr cache zip location

### DIFF
--- a/cache/pages.go
+++ b/cache/pages.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	zipUri = "https://tldr-pages.github.io/assets/tldr.zip"
+	zipUri = "https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip"
 	rawUri = "https://raw.githubusercontent.com/tldr-pages/tldr/main/pages/"
 )
 


### PR DESCRIPTION
Hi, I am an upstream maintainer from tldr. This PR updates the tldr cache location to use GitHub releases instead of the deprecated method of providing assets from the website repo.

See https://github.com/tldr-pages/tldr/releases/tag/v2.2 and https://github.com/tldr-pages/tldr/issues/20832 for more information.